### PR TITLE
fix: missing Qt's PrintSupport include

### DIFF
--- a/slimcoin-qt.pro
+++ b/slimcoin-qt.pro
@@ -11,7 +11,7 @@ CONFIG += thread
 CONFIG += static
 }
 
-QT += network webkit widgets
+QT += network webkit widgets printsupport
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
 greaterThan(QT_MAJOR_VERSION, 4) {
     QT += webkitwidgets


### PR DESCRIPTION
Fixes problems with this compilation error: **Cannot open include file: 'QtPrintSupport': No such file or directory**
I'm using Qt Creator 3.5.1 & Qt 5.5.1 under Ubuntu 16.04 x64