### PR TITLE
added declaration of signal reserveBalanceChanged

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -54,7 +54,7 @@ private:
     bool fMinimizeOnClose;
 signals:
     void displayUnitChanged(int unit);
-    // void reserveBalanceChanged(qint64 resbal);
+    void reserveBalanceChanged(qint64 resbal);
 
 public slots:
 


### PR DESCRIPTION
Not sure if this is worthy of a pull request but I've spotted a warning that appears during the app start:

`No such signal OptionsModel::reserveBalanceChanged(qint64) in src/qt/overviewpage.cpp:267`

In **optionsmodel.h** the signal reserveBalanceChanged(qint64 resbal) was commented out, for whatever reason. Maybe some upcoming changes I know nothing about?

Regards,